### PR TITLE
Feature/TTS SSML Tagging

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mix-demo-client",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "private": true,
   "description": "Sample demo client with a Python Az Func backend, and Gatsby+React frontend.",
   "author": "nirvana.tikku@nuance.com",

--- a/src/components/shared.js
+++ b/src/components/shared.js
@@ -11,7 +11,7 @@ import { navigate } from "gatsby"
 import axios from "axios"
 
 export const ROOT_URL = process.env.NODE_ENV === 'production' ? '' : 'https://localhost:7071'
-export const VERSION = '1.2.0'
+export const VERSION = '1.3.0'
 export const CLIENT_DATA = {
     "version": VERSION,
     "client": "Nuance Mix Demo Client - Azure StaticWebApps",

--- a/src/components/ttsaas.js
+++ b/src/components/ttsaas.js
@@ -452,7 +452,7 @@ export default class TTSaaS extends BaseClass {
 
   getSynthesizeHtml() {
     let [voiceOptions, ssmlVoiceOptions] = this.getVoicesSelectOptions();
-    const voice = {
+    const voiceTag = {
       tag: 'voice',
       container: true,
       name: 'Voice Tag',
@@ -511,11 +511,11 @@ export default class TTSaaS extends BaseClass {
                     </div>
                     {this.state.selectVoiceTagActive && 
                       <Form.Group className="form-floating mb-2" style={{marginLeft: "2rem"}}>
-                        <Form.Control value={this.state.defaultSSMLValue} name={VOICE_NAME} as="select" onChange={(evt) => this.addSSML(evt, {voice})} onFocus={() => this.refs.textToSynthesize.focus()}>
+                        <Form.Control value={this.state.defaultSSMLValue} name={VOICE_NAME} as="select" onChange={(evt) => this.addSSML(evt, {voice: voiceTag})} onFocus={() => this.refs.textToSynthesize.focus()}>
                           <option disabled value={DEFAULT_SSML_VALUE}>{""}</option>
                           { voiceOptions }
                         </Form.Control>
-                        <Form.Label htmlFor={VOICE_NAME} className="text-capitalize">{voice.name}</Form.Label>
+                        <Form.Label htmlFor={VOICE_NAME} className="text-capitalize">{voiceTag.name}</Form.Label>
                       </Form.Group>
                     }
                     {Object.entries(SSML_OPTIONS).map(([ssmlName, ssmlOptions], index) => {

--- a/src/components/ttsaas.js
+++ b/src/components/ttsaas.js
@@ -475,15 +475,22 @@ export default class TTSaaS extends BaseClass {
                     </Form.Group>
                     {Object.entries(SSML_OPTIONS).map(([ssmlName, ssmlOptions], index) => {
                       return (
-                        <Form.Group className="form-floating mb-2" key={index}>
-                          <Form.Control defaultValue="DEFAULT" name={ssmlName} as="select" onChange={this.addSSML.bind(this)} onFocus={() => this.refs.textToSynthesize.focus()}>
-                            <option disabled value="DEFAULT">-- SELECT A VALUE --</option>
-                            { Object.entries(ssmlOptions.options).map(([ssmlOption, _], idx) => 
-                              <option key={`${index}-${idx}`} value={ssmlOption}>{ssmlOption}</option> 
-                            )}
-                          </Form.Control>
-                          <Form.Label htmlFor={ssmlName} className="text-capitalize">{ssmlOptions.name}</Form.Label>
-                        </Form.Group>
+                        <div className="d-flex" key={index}>
+                          <Form.Group className="form-floating mb-2 w-100">
+                            <Form.Control defaultValue="DEFAULT" name={ssmlName} as="select" onChange={this.addSSML.bind(this)} onFocus={() => this.refs.textToSynthesize.focus()}>
+                              <option disabled value="DEFAULT">{""}</option>
+                              { Object.entries(ssmlOptions.options).map(([ssmlOption, _], idx) => 
+                                <option key={`${index}-${idx}`} value={ssmlOption}>{ssmlOption}</option> 
+                              )}
+                            </Form.Control>
+                            <Form.Label htmlFor={ssmlName} className="text-capitalize">{ssmlOptions.name}</Form.Label>
+                          </Form.Group>
+                          <a href={ssmlOptions.url} className="mb-2" target="_blank" rel="noopener noreferrer" style={{"margin-left": ".5rem"}}>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="32" height="100%" fill="currentColor" class="bi bi-question-square-fill" viewBox="0 0 16 16">
+                              <path d="M2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2H2zm3.496 6.033a.237.237 0 0 1-.24-.247C5.35 4.091 6.737 3.5 8.005 3.5c1.396 0 2.672.73 2.672 2.24 0 1.08-.635 1.594-1.244 2.057-.737.559-1.01.768-1.01 1.486v.105a.25.25 0 0 1-.25.25h-.81a.25.25 0 0 1-.25-.246l-.004-.217c-.038-.927.495-1.498 1.168-1.987.59-.444.965-.736.965-1.371 0-.825-.628-1.168-1.314-1.168-.803 0-1.253.478-1.342 1.134-.018.137-.128.25-.266.25h-.825zm2.325 6.443c-.584 0-1.009-.394-1.009-.927 0-.552.425-.94 1.01-.94.609 0 1.028.388 1.028.94 0 .533-.42.927-1.029.927z"/>
+                            </svg>
+                          </a>
+                        </div>
                         )
                     })}
                     <Button disabled={this.state.textInput.length === 0 || this.state.processing === ProcessingState.IN_FLIGHT} variant="secondary" 

--- a/src/components/ttsaas.js
+++ b/src/components/ttsaas.js
@@ -12,6 +12,8 @@ import loadable from '@loadable/component'
 
 import Button from "react-bootstrap/Button"
 import Form from 'react-bootstrap/Form'
+import Row from 'react-bootstrap/Row'
+import Col from 'react-bootstrap/Col'
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faPlay } from '@fortawesome/free-solid-svg-icons'
@@ -394,35 +396,78 @@ export default class TTSaaS extends BaseClass {
           </div>
           <div className="col-12">
             <div className="row" style={{height: '100%'}}>
-              <form className="form" onSubmit={
+              <Form onSubmit={
                   (evt) => {
                     evt.preventDefault();
                     this.executeTextInput()
                   }
                 }>
-                <div className="input-group">
-                  <Form.Group style={{'height': '50px', 'width': '65%'}} className="form-floating">
-                    <Form.Control name="textInput" type="text" value={this.state.textInput} placeholder="Start typing here..." onChange={this.onChangeTextInput.bind(this)}/>
-                    <Form.Label htmlFor="textInput">Text to Synthesize</Form.Label>
-                  </Form.Group>
-                  <Form.Group style={{'width': '10%'}} className="form-floating px-3 position-relative end-0 mt-0 mb-0 border">
-                    <Form.Check label={`SSML`} className="align-middle my-3" type="checkbox" name="ssml" checked={this.state.ssmlInput} onChange={evt => {this.setState({ssmlInput: !this.state.ssmlInput})}}></Form.Check>
-                  </Form.Group>
-                  <Form.Group style={{'width': '15%'}} className="form-floating">
-                    <Form.Control name="voice" as="select" value={this.state.voice.name} onChange={this.onChangeVoice.bind(this)}>
-                      { voiceOptions }
-                    </Form.Control>
-                    <Form.Label htmlFor="voice">Voice</Form.Label>
-                  </Form.Group>
-                  <button disabled={this.state.textInput.length === 0 || this.state.processing === ProcessingState.IN_FLIGHT} className="btn btn-secondary" 
-                    type="submit" style={{'width': '10%'}}>Synthesize</button>
-                </div>
+                <Row>
+                  <label className="switch mx-2 mb-2 p-0">
+                      <input type="checkbox" name="ssml" checked={this.state.ssmlInput} onChange={evt => {this.setState({ssmlInput: !this.state.ssmlInput})}}/>
+                      <div className="slider round"/>
+                  </label>
+                </Row>
+                <Row>
+                  <Col sm={12} md={8}>
+                    <Form.Group className="form-floating h-100">
+                      <Form.Control className="h-100" name="textInput" type="text" as="textarea" value={this.state.textInput} placeholder="Start typing here..." onChange={this.onChangeTextInput.bind(this)}/>
+                      <Form.Label htmlFor="textInput">Text to Synthesize</Form.Label>
+                    </Form.Group>
+                  </Col>
+                  <Col sm={6} md={4}>
+                    <Form.Group className="form-floating mb-2 mt-sm-2 mt-md-0">
+                      <Form.Control name="voice" as="select" value={this.state.voice.name} onChange={this.onChangeVoice.bind(this)}>
+                        { voiceOptions }
+                      </Form.Control>
+                      <Form.Label htmlFor="voice">Voice</Form.Label>
+                    </Form.Group>
+                    <Form.Group className="form-floating mb-2">
+                      <Form.Control name="speakingStyle" as="select">
+                        { voiceOptions.slice(0,3) }
+                      </Form.Control>
+                      <Form.Label htmlFor="speakingStyle">Speaking Style</Form.Label>
+                    </Form.Group>
+                    <Form.Group className="form-floating mb-2">
+                      <Form.Control name="pause" as="select">
+                        { voiceOptions.slice(0,3) }
+                      </Form.Control>
+                      <Form.Label htmlFor="pause">Pause</Form.Label>
+                    </Form.Group>
+                    <Form.Group className="form-floating mb-2">
+                      <Form.Control name="pause" as="select">
+                        { voiceOptions.slice(0,3) }
+                      </Form.Control>
+                      <Form.Label htmlFor="pause">Pause</Form.Label>
+                    </Form.Group>
+                    <Form.Group className="form-floating mb-2">
+                      <Form.Control name="timbre" as="select">
+                        { voiceOptions.slice(0,3) }
+                      </Form.Control>
+                      <Form.Label htmlFor="timbre">Timbre</Form.Label>
+                    </Form.Group>
+                    <Form.Group className="form-floating mb-2">
+                      <Form.Control name="pitch" as="select">
+                        { voiceOptions.slice(0,3) }
+                      </Form.Control>
+                      <Form.Label htmlFor="pitch">Pitch</Form.Label>
+                    </Form.Group>
+                    <Form.Group className="form-floating mb-2">
+                      <Form.Control name="speechRate" as="select">
+                        { voiceOptions.slice(0,3) }
+                      </Form.Control>
+                      <Form.Label htmlFor="speechRate">Speech Rate</Form.Label>
+                    </Form.Group>
+                    <Button disabled={this.state.textInput.length === 0 || this.state.processing === ProcessingState.IN_FLIGHT} variant="secondary" 
+                    type="submit">Synthesize</Button>
+                  </Col>
+                </Row>
                 { this.state.error ? (
                   <div className="badge bg-danger text-white w-100 text-wrap mt-2">
                     {JSON.stringify(this.state.error)}
                   </div>
                 ) : ('') }
-              </form>
+              </Form>
             </div>
           </div>
         </div>

--- a/src/components/ttsaas.js
+++ b/src/components/ttsaas.js
@@ -19,6 +19,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faPlay } from '@fortawesome/free-solid-svg-icons'
 
 import { BaseClass, AuthForm, CLIENT_DATA, ROOT_URL, LANG_EMOJIS } from "./shared"
+import { SSML_OPTIONS } from "../utility/ssml-options"
 
 const ReactJson = loadable(() => import('react-json-view'))
 const Tabs = loadable(() => import('react-bootstrap/Tabs'))
@@ -422,42 +423,21 @@ export default class TTSaaS extends BaseClass {
                       </Form.Control>
                       <Form.Label htmlFor="voice">Voice</Form.Label>
                     </Form.Group>
-                    <Form.Group className="form-floating mb-2">
-                      <Form.Control name="speakingStyle" as="select">
-                        { voiceOptions.slice(0,3) }
-                      </Form.Control>
-                      <Form.Label htmlFor="speakingStyle">Speaking Style</Form.Label>
-                    </Form.Group>
-                    <Form.Group className="form-floating mb-2">
-                      <Form.Control name="pause" as="select">
-                        { voiceOptions.slice(0,3) }
-                      </Form.Control>
-                      <Form.Label htmlFor="pause">Pause</Form.Label>
-                    </Form.Group>
-                    <Form.Group className="form-floating mb-2">
-                      <Form.Control name="pause" as="select">
-                        { voiceOptions.slice(0,3) }
-                      </Form.Control>
-                      <Form.Label htmlFor="pause">Pause</Form.Label>
-                    </Form.Group>
-                    <Form.Group className="form-floating mb-2">
-                      <Form.Control name="timbre" as="select">
-                        { voiceOptions.slice(0,3) }
-                      </Form.Control>
-                      <Form.Label htmlFor="timbre">Timbre</Form.Label>
-                    </Form.Group>
-                    <Form.Group className="form-floating mb-2">
-                      <Form.Control name="pitch" as="select">
-                        { voiceOptions.slice(0,3) }
-                      </Form.Control>
-                      <Form.Label htmlFor="pitch">Pitch</Form.Label>
-                    </Form.Group>
-                    <Form.Group className="form-floating mb-2">
-                      <Form.Control name="speechRate" as="select">
-                        { voiceOptions.slice(0,3) }
-                      </Form.Control>
-                      <Form.Label htmlFor="speechRate">Speech Rate</Form.Label>
-                    </Form.Group>
+                    {Object.entries(SSML_OPTIONS).map(([ssmlName, ssmlOptions], index) => {
+                      return (
+                        <Form.Group className="form-floating mb-2" key={index}>
+                          <Form.Control defaultValue="DEFAULT" name={ssmlOptions.name} as="select" onChange={(event) => console.log(event.target.name, "event.target.value:", event.target.value)}>
+                            <option disabled value="DEFAULT">Select a value to add a tag</option>
+                            { Object.entries(ssmlOptions.options).map(([ssmlOption, _], idx) => {
+                              return (
+                                <option key={`${index}-${idx}`} value={ssmlOption}>{ssmlOption}</option> 
+                              )
+                            })}
+                          </Form.Control>
+                          <Form.Label htmlFor={ssmlOptions.name} className="text-capitalize">{ssmlName}</Form.Label>
+                        </Form.Group>
+                        )
+                    })}
                     <Button disabled={this.state.textInput.length === 0 || this.state.processing === ProcessingState.IN_FLIGHT} variant="secondary" 
                     type="submit">Synthesize</Button>
                   </Col>

--- a/src/components/ttsaas.js
+++ b/src/components/ttsaas.js
@@ -19,7 +19,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faPlay } from '@fortawesome/free-solid-svg-icons'
 
 import { BaseClass, AuthForm, CLIENT_DATA, ROOT_URL, LANG_EMOJIS } from "./shared"
-import { NEEDS_INPUT, SSML_OPTIONS } from "../utility/ssml-options"
+import { DEFAULT_SSML_VALUE, NEEDS_INPUT, SSML_OPTIONS } from "../utility/ssml-options"
 
 const ReactJson = loadable(() => import('react-json-view'))
 const Tabs = loadable(() => import('react-bootstrap/Tabs'))
@@ -174,6 +174,7 @@ export default class TTSaaS extends BaseClass {
         "name": "Evan", 
         "model": "xpremium-high" 
       },
+      defaultSSMLValue: DEFAULT_SSML_VALUE,
       synthesizedAudioClips: [],
       processing: ProcessingState.IDLE,
       voices: []
@@ -477,16 +478,16 @@ export default class TTSaaS extends BaseClass {
                       return (
                         <div className="d-flex" key={index}>
                           <Form.Group className="form-floating mb-2 w-100">
-                            <Form.Control defaultValue="DEFAULT" name={ssmlName} as="select" onChange={this.addSSML.bind(this)} onFocus={() => this.refs.textToSynthesize.focus()}>
-                              <option disabled value="DEFAULT">{""}</option>
+                            <Form.Control value={this.state.defaultSSMLValue} name={ssmlName} as="select" onChange={this.addSSML.bind(this)} onFocus={() => this.refs.textToSynthesize.focus()}>
+                              <option disabled value={DEFAULT_SSML_VALUE}>{""}</option>
                               { Object.entries(ssmlOptions.options).map(([ssmlOption, _], idx) => 
                                 <option key={`${index}-${idx}`} value={ssmlOption}>{ssmlOption}</option> 
                               )}
                             </Form.Control>
                             <Form.Label htmlFor={ssmlName} className="text-capitalize">{ssmlOptions.name}</Form.Label>
                           </Form.Group>
-                          <a href={ssmlOptions.url} className="mb-2" target="_blank" rel="noopener noreferrer" style={{"margin-left": ".5rem"}}>
-                            <svg xmlns="http://www.w3.org/2000/svg" width="32" height="100%" fill="currentColor" class="bi bi-question-square-fill" viewBox="0 0 16 16">
+                          <a href={ssmlOptions.url} className="mb-2" target="_blank" rel="noopener noreferrer" style={{"marginLeft": ".5rem"}}>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="32" height="100%" fill="currentColor" className="bi bi-question-square-fill" viewBox="0 0 16 16">
                               <path d="M2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2H2zm3.496 6.033a.237.237 0 0 1-.24-.247C5.35 4.091 6.737 3.5 8.005 3.5c1.396 0 2.672.73 2.672 2.24 0 1.08-.635 1.594-1.244 2.057-.737.559-1.01.768-1.01 1.486v.105a.25.25 0 0 1-.25.25h-.81a.25.25 0 0 1-.25-.246l-.004-.217c-.038-.927.495-1.498 1.168-1.987.59-.444.965-.736.965-1.371 0-.825-.628-1.168-1.314-1.168-.803 0-1.253.478-1.342 1.134-.018.137-.128.25-.266.25h-.825zm2.325 6.443c-.584 0-1.009-.394-1.009-.927 0-.552.425-.94 1.01-.94.609 0 1.028.388 1.028.94 0 .533-.42.927-1.029.927z"/>
                             </svg>
                           </a>

--- a/src/components/ttsaas.js
+++ b/src/components/ttsaas.js
@@ -487,8 +487,8 @@ export default class TTSaaS extends BaseClass {
                 <Row>
                   <Col sm={12} md={8}>
                     <Form.Group className="form-floating h-100">
-                      <Form.Control className="h-100" name="textInput" type="text" as="textarea" value={this.state.textInput} placeholder="Start typing here..." onChange={this.onChangeTextInput.bind(this)} ref='textToSynthesize'/>
-                      <Form.Label htmlFor="textInput">Text to Synthesize</Form.Label>
+                      <Form.Control className={(!this.state.textInput || this.state.textInput.length <= 0) ? "h-100" : "h-100 pt-2"} name="textInput" type="text" as="textarea" value={this.state.textInput} placeholder="Start typing here..." onChange={this.onChangeTextInput.bind(this)} ref='textToSynthesize'/>
+                      {(!this.state.textInput || this.state.textInput.length <= 0) && <Form.Label htmlFor="textInput">Text to Synthesize</Form.Label>}
                     </Form.Group>
                   </Col>
                   <Col sm={6} md={4}>

--- a/src/components/ttsaas.js
+++ b/src/components/ttsaas.js
@@ -288,11 +288,20 @@ export default class TTSaaS extends BaseClass {
     let res = await this.synthesize(payload)
     rawResponses.unshift(res);
     if(res.response?.payload.status.code !== 200){
-      this.setState({
-        rawResponses: rawResponses,
-        error: res.response.payload.status.details,
-        processing: ProcessingState.IDLE,
-      })
+      if(res.error && !res.response){
+        this.setState({
+          rawResponses: rawResponses,
+          error: res.error.message,
+          processing: ProcessingState.IDLE,
+        })
+      }
+      else{
+        this.setState({
+          rawResponses: rawResponses,
+          error: res.response.payload.status.details,
+          processing: ProcessingState.IDLE,
+        })
+      }
     } else {
       synthesizedAudioClips.unshift(
         new SynthesisRequest(payload, res))
@@ -421,7 +430,8 @@ export default class TTSaaS extends BaseClass {
       }
       textInput = textInput.substring(0, cursorStartIndex) + ssmlWrappedText + textInput.substring(cursorEndIndex);
       this.setState({
-        textInput
+        textInput,
+        ssmlInput: true
       }, () => {
         if(newCursorIndex !== undefined){
           newCursorIndex += cursorStartIndex;
@@ -490,11 +500,11 @@ export default class TTSaaS extends BaseClass {
                           <Form.Label htmlFor="voice">Voice</Form.Label>
                         </Form.Group>
                         {!this.state.selectVoiceTagActive && 
-                          <div className="mb-2" style={{marginLeft: ".5rem"}}>
-                            <svg xmlns="http://www.w3.org/2000/svg" width="32" height="100%" fill="currentColor" className="bi bi-question-square-fill" viewBox="0 0 16 16">
-                              <path className="btn text-secondary" onClick={() => this.setState({
+                          <div className="mb-2 d-flex justify-content-center align-items-center flex-column" style={{marginLeft: ".5rem"}}>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="32" height="100%" fill="currentColor" className="bi bi-question-square-fill cursor-pointer text-secondary add-voice-btn" viewBox="0 0 16 16" onClick={() => this.setState({
                                 selectVoiceTagActive: true
-                              })} d="M2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2H2zm6.5 4.5v3h3a.5.5 0 0 1 0 1h-3v3a.5.5 0 0 1-1 0v-3h-3a.5.5 0 0 1 0-1h3v-3a.5.5 0 0 1 1 0z"/>
+                              })}>
+                              <path d="M2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2H2zm6.5 4.5v3h3a.5.5 0 0 1 0 1h-3v3a.5.5 0 0 1-1 0v-3h-3a.5.5 0 0 1 0-1h3v-3a.5.5 0 0 1 1 0z"/>
                             </svg>
                           </div>
                         }

--- a/src/stylesheets/main.css
+++ b/src/stylesheets/main.css
@@ -191,3 +191,12 @@ input:checked + .slider:after{
   top: 50%;
   left: 30%;
 }
+
+.cursor-pointer {
+  cursor: pointer;
+  transition: .5s;
+}
+
+.add-voice-btn:hover {
+  color: #5c636a !important;
+}

--- a/src/stylesheets/main.css
+++ b/src/stylesheets/main.css
@@ -118,3 +118,76 @@ pre {
   font-family: -apple-system, Roboto, sans-serif, serif;
   font-size: 0.9rem;
 }
+
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 90px;
+  height: 34px;
+}
+
+.switch input {display:none;}
+
+.slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(var(--bs-danger-rgb), 1);
+  -webkit-transition: .4s;
+  transition: .4s;
+   border-radius: 34px;
+}
+
+.slider:before {
+  position: absolute;
+  content: "";
+  height: 26px;
+  width: 26px;
+  left: 4px;
+  bottom: 4px;
+  background-color: white;
+  -webkit-transition: .4s;
+  transition: .4s;
+  border-radius: 50%;
+}
+
+input:checked + .slider {
+  background-color: rgba(var(--bs-success-rgb), 1);
+}
+
+input:focus + .slider {
+  box-shadow: 0 0 1px #2196F3;
+}
+
+input:checked + .slider:before {
+  -webkit-transform: translateX(26px);
+  -ms-transform: translateX(26px);
+  transform: translateX(55px);
+}
+
+.slider:after {
+  content: 'SSML';
+  color: white;
+  display: block;
+  position: absolute;
+  -webkit-transition: .4s;
+  transition: .4s;
+  transform: translate(50%, -50%);
+  top: 50%;
+  right: 30%;
+}
+
+input:checked + .slider:after{  
+  content: 'SSML';
+  color: white;
+  display: block;
+  position: absolute;
+  -webkit-transition: .4s;
+  transition: .4s;
+  transform: translate(-50%,-50%);
+  top: 50%;
+  left: 30%;
+}

--- a/src/utility/ssml-options.js
+++ b/src/utility/ssml-options.js
@@ -1,6 +1,6 @@
 const speakingStyle = {
     tag: 'style',
-    name: 'speakingStyle',
+    name: 'Speaking Style',
     container: true,
     attributes: ['name'],
     options: {
@@ -22,7 +22,7 @@ const speakingStyle = {
 const pause = {
     tag: 'break',
     container: false,
-    name: 'pause',
+    name: 'Pause',
     attributes: ['strength', 'time'],
     options: {
         'x-weak': {
@@ -55,7 +55,7 @@ const pause = {
 const timbre = {
     tag: 'prosody',
     container: true,
-    name: 'timbre',
+    name: 'Timbre',
     attributes: ['timbre'],
     options: {
         'x-young': {
@@ -85,7 +85,7 @@ const timbre = {
 const pitch = {
     tag: 'prosody',
     container: true,
-    name: 'pitch',
+    name: 'Pitch',
     attributes: ['pitch'],
     options: {
         'x-low': {
@@ -118,7 +118,7 @@ const pitch = {
 const speechRate = {
     tag: 'prosody',
     container: true,
-    name: 'speechRate',
+    name: 'Speech Rate',
     attributes: ['rate'],
     options: {
         'x-slow': {
@@ -158,9 +158,9 @@ const speechRate = {
 }
 
 export const SSML_OPTIONS = {
-    'Speaking Style': speakingStyle,
-    'Pause': pause,
-    'Timbre': timbre,
-    'Pitch': pitch,
-    'Speech Rate': speechRate
+    speakingStyle,
+    pause,
+    timbre,
+    pitch,
+    speechRate
 }

--- a/src/utility/ssml-options.js
+++ b/src/utility/ssml-options.js
@@ -1,3 +1,5 @@
+export const NEEDS_INPUT = "needsInput"
+
 const speakingStyle = {
     tag: 'style',
     name: 'Speaking Style',
@@ -44,10 +46,14 @@ const pause = {
             strength: 'none'
         },
         '...s': {
-            time: 's'
+            time: 's',
+            suffix: 's',
+            [`${NEEDS_INPUT}`]: true
         },
         '...ms': {
-            time: 'ms'
+            time: 'ms',
+            suffix: 'ms',
+            [`${NEEDS_INPUT}`]: true
         }
     }
 }
@@ -77,7 +83,8 @@ const timbre = {
             timbre: 'x-old'
         },
         '...': {
-            timbre: ''
+            timbre: '',
+            [`${NEEDS_INPUT}`]: true
         },
     }
 }
@@ -107,10 +114,16 @@ const pitch = {
             pitch: 'x-high'
         },
         '+...%': {
-            pitch: '+%'
+            pitch: '+%',
+            prefix: '+',
+            suffix: '%',
+            [`${NEEDS_INPUT}`]: true
         },
         '-...%': {
-            pitch: '-%'
+            pitch: '-%',
+            prefix: '-',
+            suffix: '%',
+            [`${NEEDS_INPUT}`]: true
         },
     }
 }
@@ -140,19 +153,30 @@ const speechRate = {
             rate: 'x-fast'
         },
         '...': {
-            rate: ''
+            rate: '',
+            [`${NEEDS_INPUT}`]: true
         },
         '+...': {
-            rate: '+'
+            rate: '+',
+            prefix: '+',
+            [`${NEEDS_INPUT}`]: true
         },
         '-...': {
-            rate: '-'
+            rate: '-',
+            prefix: '-',
+            [`${NEEDS_INPUT}`]: true
         },
         '+...%': {
-            rate: '+%'
+            rate: '+%',
+            prefix: '+',
+            suffix: '%',
+            [`${NEEDS_INPUT}`]: true
         },
         '-...%': {
-            rate: '-%'
+            rate: '-%',
+            prefix: '-',
+            suffix: '%',
+            [`${NEEDS_INPUT}`]: true
         },
     } 
 }

--- a/src/utility/ssml-options.js
+++ b/src/utility/ssml-options.js
@@ -1,0 +1,166 @@
+const speakingStyle = {
+    tag: 'style',
+    name: 'speakingStyle',
+    container: true,
+    attributes: ['name'],
+    options: {
+        neutral: {
+            name: 'neutral'
+        },
+        lively: {
+            name: 'lively'
+        },
+        forceful: {
+            name: 'forceful'
+        },
+        apologetic: {
+            name: 'apologetic'
+        },
+    }
+}
+
+const pause = {
+    tag: 'break',
+    container: false,
+    name: 'pause',
+    attributes: ['strength', 'time'],
+    options: {
+        'x-weak': {
+            strength: 'x-weak'
+        },
+        weak: {
+            strength: 'weak'
+        },
+        medium: {
+            strength: 'medium'
+        },
+        strong: {
+            strength: 'strong'
+        },
+        'x-strong': {
+            strength: 'x-strong'
+        },
+        none: {
+            strength: 'none'
+        },
+        '...s': {
+            time: 's'
+        },
+        '...ms': {
+            time: 'ms'
+        }
+    }
+}
+
+const timbre = {
+    tag: 'prosody',
+    container: true,
+    name: 'timbre',
+    attributes: ['timbre'],
+    options: {
+        'x-young': {
+            timbre: 'x-young'
+        },
+        young: {
+            timbre: 'young'
+        },
+        medium: {
+            timbre: 'medium'
+        },
+        default: {
+            timbre: 'default'
+        },
+        old: {
+            timbre: 'old'
+        },
+        'x-old': {
+            timbre: 'x-old'
+        },
+        '...': {
+            timbre: ''
+        },
+    }
+}
+
+const pitch = {
+    tag: 'prosody',
+    container: true,
+    name: 'pitch',
+    attributes: ['pitch'],
+    options: {
+        'x-low': {
+            pitch: 'x-low'
+        },
+        low: {
+            pitch: 'low'
+        },
+        medium: {
+            pitch: 'medium'
+        },
+        default: {
+            pitch: 'default'
+        },
+        high: {
+            pitch: 'high'
+        },
+        'x-high': {
+            pitch: 'x-high'
+        },
+        '+...%': {
+            pitch: '+%'
+        },
+        '-...%': {
+            pitch: '-%'
+        },
+    }
+}
+
+const speechRate = {
+    tag: 'prosody',
+    container: true,
+    name: 'speechRate',
+    attributes: ['rate'],
+    options: {
+        'x-slow': {
+            rate: 'x-slow'
+        },
+        slow: {
+            rate: 'slow'
+        },
+        medium: {
+            rate: 'medium'
+        },
+        default: {
+            rate: 'default'
+        },
+        fast: {
+            rate: 'fast'
+        },
+        'x-fast': {
+            rate: 'x-fast'
+        },
+        '...': {
+            rate: ''
+        },
+        '+...': {
+            rate: '+'
+        },
+        '-...': {
+            rate: '-'
+        },
+        '+...%': {
+            rate: '+%'
+        },
+        '-...%': {
+            rate: '-%'
+        },
+    } 
+}
+
+export const SSML_OPTIONS = {
+    'Speaking Style': speakingStyle,
+    'Pause': pause,
+    'Timbre': timbre,
+    'Pitch': pitch,
+    'Speech Rate': speechRate
+}

--- a/src/utility/ssml-options.js
+++ b/src/utility/ssml-options.js
@@ -90,6 +90,18 @@ const timbre = {
             timbre: '',
             [`${NEEDS_INPUT}`]: true
         },
+        '+...%': {
+            timbre: '+%',
+            prefix: '+',
+            suffix: '%',
+            [`${NEEDS_INPUT}`]: true
+        },
+        '-...%': {
+            timbre: '-%',
+            prefix: '-',
+            suffix: '%',
+            [`${NEEDS_INPUT}`]: true
+        },
     }
 }
 

--- a/src/utility/ssml-options.js
+++ b/src/utility/ssml-options.js
@@ -3,6 +3,7 @@ export const NEEDS_INPUT = "needsInput"
 const speakingStyle = {
     tag: 'style',
     name: 'Speaking Style',
+    url: 'https://docs.mix.nuance.com/tts-grpc/v1/#style',
     container: true,
     attributes: ['name'],
     options: {
@@ -25,6 +26,7 @@ const pause = {
     tag: 'break',
     container: false,
     name: 'Pause',
+    url: 'https://docs.mix.nuance.com/tts-grpc/v1/#break',
     attributes: ['strength', 'time'],
     options: {
         'x-weak': {
@@ -62,6 +64,7 @@ const timbre = {
     tag: 'prosody',
     container: true,
     name: 'Timbre',
+    url: 'https://docs.mix.nuance.com/tts-grpc/v1/#prosody-timbre',
     attributes: ['timbre'],
     options: {
         'x-young': {
@@ -93,6 +96,7 @@ const pitch = {
     tag: 'prosody',
     container: true,
     name: 'Pitch',
+    url: 'https://docs.mix.nuance.com/tts-grpc/v1/#prosody-pitch',
     attributes: ['pitch'],
     options: {
         'x-low': {
@@ -133,6 +137,7 @@ const speechRate = {
     container: true,
     name: 'Speech Rate',
     attributes: ['rate'],
+    url: 'https://docs.mix.nuance.com/tts-grpc/v1/#prosody-rate',
     options: {
         'x-slow': {
             rate: 'x-slow'

--- a/src/utility/ssml-options.js
+++ b/src/utility/ssml-options.js
@@ -1,4 +1,5 @@
 export const NEEDS_INPUT = "needsInput"
+export const DEFAULT_SSML_VALUE = "DEFAULT"
 
 const speakingStyle = {
     tag: 'style',


### PR DESCRIPTION
- Redesign the TTSaaS page to give users the ability to easily add SSML tags to their text
  - The supported tag and attribute combinations are:
    - `prosody` (with the `timbre`, `pitch`, and `rate` attributes)
    - `break` (with the `strength` and `time` attributes)
    - `style` (with the `name` attribute)
    - `voice` (with the `name` attribute)
  - Users can select text and then choose the tag and attribute/value combination they want to apply to the selected text
  - As soon as an SSML tag is added to the text, the SSML option is enabled so that any synthesized text will use SSML
  - If the chosen tag/value combination requires more input (e.g. they chose the prosody tag with a relative percentage pitch) then the cursor will move to the location where more input is needed
- Fixed an issue where no error was being displayed and the synthesize button became disabled when the user enters valid SSML but the request times out (this would occur occasionally when using the `voice` tag)